### PR TITLE
Fix duplicated `type` key for `data` and `target` objects in JSON out…

### DIFF
--- a/src/main/java/cc/mallet/json/schema/JsonDataObject.java
+++ b/src/main/java/cc/mallet/json/schema/JsonDataObject.java
@@ -1,5 +1,6 @@
 package cc.mallet.json.schema;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,5 +32,6 @@ public abstract class JsonDataObject {
         this.alphabetRef = alphabetRef;
     }
 
+    @JsonIgnore
     public abstract String getType();
 }

--- a/src/main/java/cc/mallet/json/schema/JsonTargetObject.java
+++ b/src/main/java/cc/mallet/json/schema/JsonTargetObject.java
@@ -1,5 +1,6 @@
 package cc.mallet.json.schema;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,5 +32,6 @@ public abstract class JsonTargetObject {
         this.alphabetRef = alphabetRef;
     }
 
+    @JsonIgnore
     public abstract String getType();
 }


### PR DESCRIPTION
…put.

Fix duplicated `type` key for `data` and `target` objects in JSON output.

Fixes: https://github.com/mimno/MalletJSON/issues/1